### PR TITLE
fs/ntfs3: Fix unsupported flags by clang

### DIFF
--- a/fs/ntfs3/Makefile
+++ b/fs/ntfs3/Makefile
@@ -4,7 +4,11 @@
 #
 
 # to check robot warnings
-ccflags-y += -Wunused-but-set-variable -Wold-style-declaration -Wint-to-pointer-cast
+ccflags-y += -Wint-to-pointer-cast
+condflags := \
+	$(call cc-option, -Wunused-but-set-variable) \
+	$(call cc-option, -Wold-style-declaration)
+ccflags-y += $(condflags)
 
 obj-$(CONFIG_NTFS3_FS) += ntfs3.o
 


### PR DESCRIPTION
These flags are not supported by clang, therefore this change makes them facultative depending on the compiler.
I used fs/btrfs/Makefile as example.