### PR TITLE
TT v0.3

### DIFF
--- a/include/linux/sched/sysctl.h
+++ b/include/linux/sched/sysctl.h
@@ -29,6 +29,7 @@ enum { sysctl_hung_task_timeout_secs = 0 };
 extern unsigned int sysctl_sched_child_runs_first;
 
 #ifdef CONFIG_TT_SCHED
+extern unsigned int tt_balancer_opt;
 extern unsigned int tt_max_lifetime;
 extern int tt_rt_prio;
 #endif

--- a/kernel/sched/bs.c
+++ b/kernel/sched/bs.c
@@ -1063,7 +1063,7 @@ select_task_rq_fair(struct task_struct *p, int prev_cpu, int wake_flags)
 		}
 
 		if (IS_GRQ_BL_ENABLED)
-			return new_cpu;
+			return smp_processor_id();
 
 		if (cpu_rq(cpu)->nr_running < min) {
 			new_cpu = cpu;

--- a/kernel/sched/bs_nohz.h
+++ b/kernel/sched/bs_nohz.h
@@ -456,6 +456,14 @@ static void idle_balance(struct rq *this_rq)
 	unsigned int max = 0;
 	struct rq_flags src_rf;
 
+	if (IS_CAND_BL_ENABLED) {
+		if (idle_pull_global_candidate(this_rq))
+			return;
+	} else if (IS_GRQ_BL_ENABLED) {
+		pull_from_grq(this_rq);
+		return;
+	}
+
 	for_each_online_cpu(cpu) {
 		/*
 		 * Stop searching for tasks to pull if there are

--- a/kernel/sched/idle.c
+++ b/kernel/sched/idle.c
@@ -261,6 +261,9 @@ exit_idle:
 static void do_idle(void)
 {
 	int cpu = smp_processor_id();
+#ifdef CONFIG_TT_SCHED
+	int pm_disabled = per_cpu(nr_lat_sensitive, cpu);
+#endif
 
 	/*
 	 * Check if we need to update blocked load
@@ -299,7 +302,11 @@ static void do_idle(void)
 		 * broadcast device expired for us, we don't want to go deep
 		 * idle as we know that the IPI is going to arrive right away.
 		 */
-		if (cpu_idle_force_poll || tick_check_broadcast_expired()) {
+		if (cpu_idle_force_poll || tick_check_broadcast_expired()
+#ifdef CONFIG_TT_SCHED
+		|| pm_disabled > 0
+#endif
+		) {
 			tick_nohz_idle_restart_tick();
 			cpu_idle_poll();
 		} else {

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -91,6 +91,11 @@
 #define TT_NO_TYPE	2
 #define TT_CPU_BOUND	3
 #define TT_BATCH	4
+
+#define TT_BL_NORM	0
+#define TT_BL_CAND	1
+#define TT_BL_GRQ	2
+extern struct rq *grq;
 #endif
 
 struct rq;
@@ -205,6 +210,15 @@ static inline int task_has_dl_policy(struct task_struct *p)
 {
 	return dl_policy(p->policy);
 }
+
+#ifdef CONFIG_TT_SCHED
+static inline int task_is_lat_sensitive(struct task_struct *p)
+{
+	unsigned int tt = p->se.tt_node.task_type;
+
+	return (tt == TT_INTERACTIVE);
+}
+#endif
 
 #define cap_scale(v, s) ((v)*(s) >> SCHED_CAPACITY_SHIFT)
 
@@ -561,6 +575,7 @@ struct cfs_rq {
 	struct sched_entity	*curr;
 #ifdef CONFIG_TT_SCHED
 	struct tt_node		*head;
+	u64			local_cand_hrrn;
 #else
 	struct sched_entity	*next;
 	struct sched_entity	*last;
@@ -990,6 +1005,9 @@ struct rq {
 	struct task_struct	*idle;
 	struct task_struct	*stop;
 	unsigned long		next_balance;
+#ifdef CONFIG_TT_SCHED
+	unsigned long		lat_decay;
+#endif
 	struct mm_struct	*prev_mm;
 
 	unsigned int		clock_update_flags;
@@ -1794,6 +1812,9 @@ DECLARE_PER_CPU(struct sched_domain_shared __rcu *, sd_llc_shared);
 DECLARE_PER_CPU(struct sched_domain __rcu *, sd_numa);
 DECLARE_PER_CPU(struct sched_domain __rcu *, sd_asym_packing);
 DECLARE_PER_CPU(struct sched_domain __rcu *, sd_asym_cpucapacity);
+#ifdef CONFIG_TT_SCHED
+DECLARE_PER_CPU(int, nr_lat_sensitive);
+#endif
 extern struct static_key_false sched_asym_cpucapacity;
 
 struct sched_group_capacity {
@@ -2265,6 +2286,10 @@ extern void update_group_capacity(struct sched_domain *sd, int cpu);
 
 extern void trigger_load_balance(struct rq *rq);
 
+#ifdef CONFIG_TT_SCHED
+extern int idle_pull_global_candidate(struct rq *dist_rq);
+#endif
+
 extern void set_cpus_allowed_common(struct task_struct *p, const struct cpumask *new_mask, u32 flags);
 
 static inline struct task_struct *get_push_task(struct rq *rq)
@@ -2408,6 +2433,10 @@ extern void activate_task(struct rq *rq, struct task_struct *p, int flags);
 extern void deactivate_task(struct rq *rq, struct task_struct *p, int flags);
 
 extern void check_preempt_curr(struct rq *rq, struct task_struct *p, int flags);
+
+#ifdef CONFIG_TT_SCHED
+extern inline void dec_nr_lat_sensitive(unsigned int cpu);
+#endif
 
 extern const_debug unsigned int sysctl_sched_nr_migrate;
 extern const_debug unsigned int sysctl_sched_migration_cost;

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -115,7 +115,7 @@ static int sixty = 60;
 
 #ifdef CONFIG_TT_SCHED
 static int neg_twenty	= -20;
-static int thirty_nine	= 39;
+static int nineteen	= 19;
 #endif
 static int __maybe_unused neg_one = -1;
 static int __maybe_unused two = 2;
@@ -1806,6 +1806,15 @@ static struct ctl_table kern_table[] = {
 	},
 #ifdef CONFIG_TT_SCHED
 	{
+		.procname	= "sched_tt_balancer_opt",
+		.data		= &tt_balancer_opt,
+		.maxlen		= sizeof(int),
+		.mode		= 0644,
+		.proc_handler	= proc_dointvec_minmax,
+		.extra1		= &zero_ul,
+		.extra2		= &two,
+	},
+	{
 		.procname	= "sched_tt_max_lifetime",
 		.data		= &tt_max_lifetime,
 		.maxlen		= sizeof(unsigned int),
@@ -1819,7 +1828,7 @@ static struct ctl_table kern_table[] = {
 		.mode		= 0644,
 		.proc_handler	= proc_dointvec_minmax,
 		.extra1		= &neg_twenty,
-		.extra2		= &thirty_nine,
+		.extra2		= &nineteen,
 	},
 #endif
 #ifdef CONFIG_SCHEDSTATS


### PR DESCRIPTION
# New in TT v0.3

- Fix the possibility of div. over zero in HRRN calculation.
- set sysctl `sched_tt_rt_prio` max from 39 to 19
- Added Candidate Balancer (only for `REALTIME` and `INTERACTIVE` tasks)
- Added Global Runqueue (GRQ)
- Added latency sensitive patch (adjusted for TT work)
	- Issue (https://github.com/hamadmarri/TT-CPU-Scheduler/issues/8)
	- Only `INTERACTIVE` tasks which contribute to `nr_lat_sensitive`
	- Special case for `REALTIME` tasks when they dequeue for sleep,
	  if `avg. wait time <= next_tick_due`, then contribute to `nr_lat_sensitive`
	  (i.e. keep CPU active/not_idle if we have a realtime task that
	  would wakeup soon before or equal to the next tick)
	- decay `nr_lat_sensitive` by 1 every 4ms

## New sysctl
`kernel.sched_tt_balancer_opt`

It can be set to 3 values:

- 0: Normal TT balancer
- 1: Candidate Balancer (which is an addition to normal TT balancer)
- 2: Global runqueue GRQ

You can change the balancer option at run time.

