### PR TITLE
Add -mno-tbm flag for AMD bdver2/3/4 processors

### DIFF
--- a/arch/x86/Makefile
+++ b/arch/x86/Makefile
@@ -125,9 +125,9 @@ else
         cflags-$(CONFIG_MBOBCAT) 	+= -march=btver1
         cflags-$(CONFIG_MJAGUAR) 	+= -march=btver2
         cflags-$(CONFIG_MBULLDOZER) 	+= -march=bdver1
-        cflags-$(CONFIG_MPILEDRIVER)	+= -march=bdver2
-        cflags-$(CONFIG_MSTEAMROLLER) 	+= -march=bdver3
-        cflags-$(CONFIG_MEXCAVATOR) 	+= -march=bdver4
+        cflags-$(CONFIG_MPILEDRIVER)	+= -march=bdver2 -mno-tbm
+        cflags-$(CONFIG_MSTEAMROLLER) 	+= -march=bdver3 -mno-tbm
+        cflags-$(CONFIG_MEXCAVATOR) 	+= -march=bdver4 -mno-tbm
         cflags-$(CONFIG_MZEN) 		+= -march=znver1
         cflags-$(CONFIG_MZEN2) 	+= -march=znver2
         cflags-$(CONFIG_MZEN3) 	+= -march=znver3


### PR DESCRIPTION
objtool craps out in those CPUs (including my trusty FX-6300) if the -mno-tbm flag isn't passed. See [9c9c7e817dd2718566ec95f7742b162ab125316f](https://github.com/graysky2/kernel_compiler_patch/commit/9c9c7e817dd2718566ec95f7742b162ab125316f).