### PR TITLE
sched: bs_nohz: declare cfs_rq again

### DIFF
--- a/kernel/sched/bs_nohz.h
+++ b/kernel/sched/bs_nohz.h
@@ -703,6 +703,7 @@ static void nohz_try_pull_from_candidate(void)
 	struct rq *rq;
 #ifdef CONFIG_NO_HZ_FULL
 	struct rq_flags rf;
+	struct cfs_rq *cfs_rq;
 #endif
 
 	/* first, push to grq*/


### PR DESCRIPTION
Seems to have gotten removed from the general case but we still need it when
CONFIG_NO_HZ_FULL is set

Fixes https://github.com/xanmod/linux/issues/265