### PR TITLE
i2c: i2c-nct6775: fix -Wimplicit-fallthrough

### DIFF
--- a/drivers/i2c/busses/i2c-nct6775.c
+++ b/drivers/i2c/busses/i2c-nct6775.c
@@ -219,6 +219,7 @@ static s32 nct6775_access(struct i2c_adapter * adap, u16 addr,
 			break;
 		case I2C_SMBUS_BYTE_DATA:
 			tmp_data.byte = data->byte;
+			fallthrough;
 		case I2C_SMBUS_BYTE:
 			outb_p((addr << 1) | read_write,
 			       SMBHSTADD);


### PR DESCRIPTION
Depending on a compiler, `case I2C_SMBUS_BYTE_DATA` can trigger -Wimplicit-fallthrough / unannotated fallthrough as it doesn't mention it anyhow.
Add a `fallthrough` attribute to silence this.

Fixes: 480fefb8f23ab ("i2c: busses: Add SMBus capability to work with OpenRGB driver control")