### PR TITLE
Patch to fix sound on ASUS Zenbook S 13 OLED laptop model UM5302TA

### DIFF
--- a/sound/pci/hda/cs35l41_hda.c
+++ b/sound/pci/hda/cs35l41_hda.c
@@ -1231,7 +1231,7 @@ static int cs35l41_no_acpi_dsd(struct cs35l41_hda *cs35l41, struct device *physd
 
 	if (strncmp(hid, "CLSA0100", 8) == 0) {
 		hw_cfg->bst_type = CS35L41_EXT_BOOST_NO_VSPK_SWITCH;
-	} else if (strncmp(hid, "CLSA0101", 8) == 0) {
+	} else if (strncmp(hid, "CLSA0101", 8) == 0 || strncmp(hid, "CSC3551", 7) == 0) {
 		hw_cfg->bst_type = CS35L41_EXT_BOOST;
 		hw_cfg->gpio1.func = CS35l41_VSPK_SWITCH;
 		hw_cfg->gpio1.valid = true;


### PR DESCRIPTION
Applied this patch: https://aur.archlinux.org/cgit/aur.git/plain/cs35l42-hda-no-acpi-dsd-csc3551.patch?h=linux-mainline-um5302ta

Tested on KDE Neon distro based on Ubuntu 22.04 LTS (jammy jellyfish) and it works!

Will test on at least elementary OS 7 and stock Ubuntu 22.04 LTS running xanmod x64v3 kernel and report back.